### PR TITLE
fixed str return for Exercise model

### DIFF
--- a/redonkulator_app/models.py
+++ b/redonkulator_app/models.py
@@ -8,7 +8,7 @@ class Exercise(models.Model):
     logo =  models.BinaryField()
 
     def __str__(self):
-        return f"{self.name}"
+        return f"Exercise: {self.exercise}\t Evolution: {self.evolution}"
 
 class Locations(models.Model):
     location = models.CharField(max_length=45)


### PR DESCRIPTION
str return caused crash, called an erroneous variable name. fixes #28 